### PR TITLE
Redesign sign-up page with responsive layout

### DIFF
--- a/config.js
+++ b/config.js
@@ -38,9 +38,9 @@ const CONFIG = {
     
     // Event configuration
     EVENT: {
-        name: 'Team Potluck 2025',
-        date: '2025-07-15',
-        description: 'Annual team potluck dinner'
+        name: 'Shared Table RSVP \u2022 June 2025',
+        date: '2025-06-15',
+        description: 'Monthly community dinner'
     },
     
     // UI Messages

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <text y="52" font-size="52">🍅</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,66 +4,68 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Recipe Sign-Up</title>
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="container">
-        <header>
-            <h1>🍽️ Recipe Sign-Up</h1>
-            <p>Reserve your recipe for the upcoming event</p>
-        </header>
-        
-        <form id="recipeForm" class="signup-form">
-            <div class="form-group">
-                <label for="eventName">Event Name</label>
-                <input type="text" id="eventName" name="eventName" value="Team Potluck 2025" readonly>
-            </div>
-            
-            <div class="form-group">
-                <label for="member">Who are you? *</label>
-                <select id="member" name="member" required>
-                    <option value="">Select your name...</option>
-                </select>
-            </div>
-            
-            <div class="form-group">
-                <label for="cooking">Are you cooking? *</label>
-                <select id="cooking" name="cooking" required>
-                    <option value="">Select...</option>
-                    <option value="yes">Yes, I'm bringing a dish</option>
-                    <option value="no">No, just attending</option>
-                </select>
-            </div>
-            
-            <div class="form-group" id="recipeGroup" style="display:none;">
-                <label for="recipe">Choose a recipe: *</label>
-                <select id="recipe" name="recipe">
-                    <option value="">Select a recipe...</option>
-                </select>
-                <div class="recipe-info" id="recipeInfo"></div>
-            </div>
-            
-            <button type="submit" id="submitBtn" disabled>
-                <span class="btn-text">Submit RSVP</span>
-                <span class="btn-loading" style="display:none;">Submitting...</span>
-            </button>
-        </form>
-        
-        <div id="message" class="message"></div>
-        
-        <div class="info-section">
-            <h3>How it works:</h3>
-            <ul>
-                <li>Select your name from the dropdown</li>
-                <li>Choose whether you're cooking or just attending</li>
-                <li>If cooking, pick an available recipe (first come, first served!)</li>
-                <li>Submit your RSVP and get confirmation</li>
-            </ul>
-        </div>
+    <div class="layout">
+        <div class="hero" role="img" aria-label="Food on table"></div>
+        <main class="cards">
+            <section class="card header-card">
+                <h1>Shared Table RSVP • June 2025</h1>
+                <p>Come share a meal with friends and neighbors.</p>
+                <p>Claim a dish or just join the feast!</p>
+                <hr>
+            </section>
+            <section class="card form-card">
+                <form id="recipeForm" novalidate>
+                    <input type="hidden" id="eventName" name="eventName" readonly>
+                    <div class="form-group">
+                        <label for="member">Who are you? *</label>
+                        <select id="member" name="member" required>
+                            <option value="">Select your name...</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label>How are you joining? *</label>
+                        <div class="radio-group" id="cookingGroup">
+                            <label class="radio-card">
+                                <input type="radio" name="cooking" value="yes">
+                                <span class="icon">👩‍🍳</span>
+                                <span class="title">Cooking something</span>
+                                <span class="subtitle">I'll bring a dish</span>
+                            </label>
+                            <label class="radio-card">
+                                <input type="radio" name="cooking" value="no">
+                                <span class="icon">🍽️</span>
+                                <span class="title">Just showing up</span>
+                                <span class="subtitle">I'm here to eat</span>
+                            </label>
+                        </div>
+                    </div>
+                    <div class="form-group" id="recipeGroup" style="display:none;">
+                        <label for="recipe">What are you cooking? *</label>
+                        <select id="recipe" name="recipe">
+                            <option value="">Select a recipe...</option>
+                        </select>
+                        <div class="recipe-info" id="recipeInfo"></div>
+                    </div>
+                    <div class="form-group">
+                        <label for="notes">Anything else we should know?</label>
+                        <span class="sub-label">This note will post in Discord…</span>
+                        <textarea id="notes" name="notes"></textarea>
+                    </div>
+                    <button type="submit" id="submitBtn" disabled>
+                        <span class="btn-text">Submit RSVP</span>
+                        <span class="btn-loading" style="display:none;">Submitting...</span>
+                    </button>
+                </form>
+                <div id="message" class="message"></div>
+            </section>
+        </main>
     </div>
-    
+
     <script src="config.js"></script>
     <script src="script.js"></script>
 </body>
 </html>
-

--- a/script.js
+++ b/script.js
@@ -13,15 +13,18 @@ class RecipeSignupForm {
         // Get form elements
         this.form = document.getElementById('recipeForm');
         this.memberSelect = document.getElementById('member');
-        this.cookingSelect = document.getElementById('cooking');
+        this.cookingRadios = document.querySelectorAll('input[name="cooking"]');
         this.recipeSelect = document.getElementById('recipe');
         this.recipeGroup = document.getElementById('recipeGroup');
         this.recipeInfo = document.getElementById('recipeInfo');
         this.submitBtn = document.getElementById('submitBtn');
         this.messageDiv = document.getElementById('message');
+        this.notesField = document.getElementById('notes');
         
         // Add event listeners
-        this.cookingSelect.addEventListener('change', () => this.handleCookingChange());
+        this.cookingRadios.forEach(radio => {
+            radio.addEventListener('change', () => this.handleCookingChange());
+        });
         this.recipeSelect.addEventListener('change', () => this.handleRecipeChange());
         this.form.addEventListener('submit', (e) => this.handleSubmit(e));
         this.memberSelect.addEventListener('change', () => this.validateForm());
@@ -155,9 +158,22 @@ class RecipeSignupForm {
         
         console.log('🍽️ Populated recipe dropdown with', this.recipes.length, 'recipes');
     }
-    
+
+    getCookingValue() {
+        const checked = document.querySelector('input[name="cooking"]:checked');
+        return checked ? checked.value : '';
+    }
+
     handleCookingChange() {
-        const isCooking = this.cookingSelect.value === 'yes';
+        const value = this.getCookingValue();
+        this.cookingRadios.forEach(radio => {
+            if (radio.checked) {
+                radio.parentElement.classList.add('selected');
+            } else {
+                radio.parentElement.classList.remove('selected');
+            }
+        });
+        const isCooking = value === 'yes';
         
         if (isCooking) {
             this.recipeGroup.style.display = 'block';
@@ -190,8 +206,9 @@ class RecipeSignupForm {
     
     validateForm() {
         const memberSelected = this.memberSelect.value !== '';
-        const cookingSelected = this.cookingSelect.value !== '';
-        const recipeSelected = this.cookingSelect.value === 'no' || this.recipeSelect.value !== '';
+        const cookingValue = this.getCookingValue();
+        const cookingSelected = cookingValue !== '';
+        const recipeSelected = cookingValue === 'no' || this.recipeSelect.value !== '';
         
         const isValid = memberSelected && cookingSelected && recipeSelected;
         this.submitBtn.disabled = !isValid;
@@ -240,13 +257,15 @@ class RecipeSignupForm {
         const discordId = this.memberSelect.value;
         const member = this.members.find(m => m.discordId === discordId);
         
+        const cookingValue = this.getCookingValue();
         const formData = {
             eventName: document.getElementById('eventName').value,
             discordId: discordId,
             displayName: member ? member.displayName : '',
-            cooking: this.cookingSelect.value === 'yes',
-            recipeId: this.cookingSelect.value === 'yes' ? parseInt(this.recipeSelect.value) : null,
+            cooking: cookingValue === 'yes',
+            recipeId: cookingValue === 'yes' ? parseInt(this.recipeSelect.value) : null,
             recipeName: '',
+            notes: this.notesField.value.trim(),
             timestamp: new Date().toISOString()
         };
         
@@ -364,6 +383,8 @@ class RecipeSignupForm {
         this.recipeInfo.style.display = 'none';
         this.recipeSelect.required = false;
         this.submitBtn.disabled = true;
+        this.cookingRadios.forEach(r => r.parentElement.classList.remove('selected'));
+        if (this.notesField) this.notesField.value = '';
         document.getElementById('eventName').value = CONFIG.EVENT.name;
     }
 }

--- a/style.css
+++ b/style.css
@@ -1,258 +1,215 @@
-/* Reset and base styles */
+/* Base and layout */
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-    line-height: 1.6;
-    color: #333;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    min-height: 100vh;
-    padding: 20px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, sans-serif;
+  line-height: 1.5;
+  background: #F7F7F7;
+  color: #2B2B2B;
+  min-height: 100vh;
 }
 
-.container {
-    max-width: 600px;
-    margin: 0 auto;
-    background: white;
-    border-radius: 16px;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
-    overflow: hidden;
+.layout {
+  display: flex;
+  min-height: 100vh;
 }
 
-header {
-    background: linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%);
-    color: white;
-    padding: 40px 30px;
-    text-align: center;
+.hero {
+  flex: 1;
+  background: url('https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=800&q=60')
+    center/cover no-repeat;
 }
 
-header h1 {
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin-bottom: 10px;
+.cards {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+  padding: 32px;
+  background: #F7F7F7;
 }
 
-header p {
-    font-size: 1.1rem;
-    opacity: 0.9;
+.card {
+  background: #FFFFFF;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  padding: 32px;
+  width: 100%;
+  max-width: 480px;
 }
 
-.signup-form {
-    padding: 40px 30px;
+.header-card h1 {
+  font-size: 32px;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 16px;
+  color: #2B2B2B;
+}
+
+.header-card p {
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.header-card hr {
+  border: none;
+  border-top: 1px solid #e0e0e0;
+  margin-top: 16px;
 }
 
 .form-group {
-    margin-bottom: 25px;
+  margin-bottom: 24px;
 }
 
 label {
-    display: block;
-    margin-bottom: 8px;
-    font-weight: 600;
-    color: #555;
-    font-size: 0.95rem;
+  display: block;
+  margin-bottom: 16px;
+  font-weight: 600;
 }
 
-input, select {
-    width: 100%;
-    padding: 14px 16px;
-    border: 2px solid #e1e5e9;
-    border-radius: 8px;
-    font-size: 1rem;
-    transition: all 0.3s ease;
-    background: white;
+.sub-label {
+  display: block;
+  margin-top: -8px;
+  margin-bottom: 16px;
+  color: #6c6c6c;
+  font-size: 0.9em;
 }
 
-input:focus, select:focus {
-    outline: none;
-    border-color: #667eea;
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 12px 16px;
+  font-size: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  color: #2B2B2B;
 }
 
-input[readonly] {
-    background: #f8f9fa;
-    color: #6c757d;
+input:focus,
+select:focus,
+textarea:focus {
+  outline: 2px solid #6A5AF9;
+  outline-offset: 2px;
 }
 
-select {
-    cursor: pointer;
+textarea {
+  resize: vertical;
+  min-height: 90px;
 }
 
-select:invalid {
-    color: #999;
+.radio-group {
+  display: flex;
+  gap: 16px;
+}
+
+.radio-card {
+  flex: 1;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 16px;
+  text-align: center;
+  cursor: pointer;
+  position: relative;
+  user-select: none;
+}
+
+.radio-card:focus-within {
+  outline: 2px solid #6A5AF9;
+  outline-offset: 2px;
+}
+
+.radio-card input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.radio-card .icon {
+  font-size: 24px;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.radio-card .title {
+  font-weight: 600;
+}
+
+.radio-card .subtitle {
+  font-size: 0.9em;
+  color: #6c6c6c;
+}
+
+.radio-card.selected {
+  border: 2px solid #6A5AF9;
+  background: rgba(106, 90, 249, 0.05);
 }
 
 .recipe-info {
-    margin-top: 10px;
-    padding: 12px;
-    background: #f8f9fa;
-    border-radius: 6px;
-    font-size: 0.9rem;
-    color: #666;
-    display: none;
+  margin-top: 8px;
+  background: #f0f0f0;
+  padding: 12px;
+  border-radius: 8px;
 }
 
 button {
-    width: 100%;
-    padding: 16px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    border: none;
-    border-radius: 8px;
-    font-size: 1.1rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    position: relative;
-    overflow: hidden;
-}
-
-button:hover:not(:disabled) {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(102, 126, 234, 0.3);
+  width: 100%;
+  padding: 16px;
+  font-weight: 700;
+  color: #ffffff;
+  font-size: 1rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  background: linear-gradient(90deg, #6A5AF9, #FF6A5A);
 }
 
 button:disabled {
-    background: #ccc;
-    cursor: not-allowed;
-    transform: none;
-    box-shadow: none;
-}
-
-.btn-loading {
-    display: none;
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .message {
-    margin-top: 20px;
-    padding: 16px;
-    border-radius: 8px;
-    font-weight: 500;
-    text-align: center;
-    display: none;
+  margin-top: 16px;
+  padding: 12px;
+  border-radius: 8px;
+  display: none;
 }
 
 .message.success {
-    background: #d4edda;
-    color: #155724;
-    border: 1px solid #c3e6cb;
+  background: #d4edda;
+  color: #155724;
 }
 
 .message.error {
-    background: #f8d7da;
-    color: #721c24;
-    border: 1px solid #f5c6cb;
+  background: #f8d7da;
+  color: #721c24;
 }
 
 .message.info {
-    background: #d1ecf1;
-    color: #0c5460;
-    border: 1px solid #bee5eb;
+  background: #d1ecf1;
+  color: #0c5460;
 }
 
-.info-section {
-    background: #f8f9fa;
-    padding: 30px;
-    border-top: 1px solid #e9ecef;
-}
-
-.info-section h3 {
-    color: #495057;
-    margin-bottom: 15px;
-    font-size: 1.2rem;
-}
-
-.info-section ul {
-    list-style: none;
-    padding-left: 0;
-}
-
-.info-section li {
-    padding: 8px 0;
-    padding-left: 25px;
-    position: relative;
-    color: #6c757d;
-}
-
-.info-section li::before {
-    content: "✓";
-    position: absolute;
-    left: 0;
-    color: #28a745;
-    font-weight: bold;
-}
-
-/* Responsive design */
 @media (max-width: 768px) {
-    body {
-        padding: 10px;
-    }
-    
-    .container {
-        border-radius: 12px;
-    }
-    
-    header {
-        padding: 30px 20px;
-    }
-    
-    header h1 {
-        font-size: 2rem;
-    }
-    
-    .signup-form {
-        padding: 30px 20px;
-    }
-    
-    .info-section {
-        padding: 20px;
-    }
+  .layout {
+    flex-direction: column;
+  }
+  .hero {
+    height: 200px;
+  }
+  .cards {
+    padding: 24px;
+  }
+  .header-card h1 {
+    font-size: 28px;
+  }
 }
-
-/* Animation for form reveal */
-.form-group {
-    opacity: 0;
-    transform: translateY(20px);
-    animation: slideIn 0.6s ease forwards;
-}
-
-.form-group:nth-child(1) { animation-delay: 0.1s; }
-.form-group:nth-child(2) { animation-delay: 0.2s; }
-.form-group:nth-child(3) { animation-delay: 0.3s; }
-.form-group:nth-child(4) { animation-delay: 0.4s; }
-
-@keyframes slideIn {
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-/* Loading state */
-.loading {
-    position: relative;
-}
-
-.loading::after {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 20px;
-    height: 20px;
-    margin: -10px 0 0 -10px;
-    border: 2px solid #fff;
-    border-top: 2px solid transparent;
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-}
-


### PR DESCRIPTION
## Summary
- overhaul layout with hero image and stacked cards
- style form controls to match mockups
- add custom favicon
- add notes field and radio options for cooking
- update config with new event name

## Testing
- `node -c script.js`
- `node -e "console.log('test parse success')"`

------
https://chatgpt.com/codex/tasks/task_e_684d3b8a96d083238b1301727913a6d4