### PR TITLE
Improve recipe metadata display

### DIFF
--- a/config.js
+++ b/config.js
@@ -26,14 +26,94 @@ const CONFIG = {
     ],
     
     SAMPLE_RECIPES: [
-        { id: 1, name: 'Caesar Salad', description: 'Fresh romaine lettuce with homemade dressing', claimed: false, claimedByDiscordId: '', claimedAt: '' },
-        { id: 2, name: 'Garlic Bread', description: 'Crispy bread with garlic butter', claimed: false, claimedByDiscordId: '', claimedAt: '' },
-        { id: 3, name: 'Chocolate Brownies', description: 'Rich and fudgy brownies', claimed: false, claimedByDiscordId: '', claimedAt: '' },
-        { id: 4, name: 'Vegetable Stir Fry', description: 'Mixed vegetables with soy sauce', claimed: false, claimedByDiscordId: '', claimedAt: '' },
-        { id: 5, name: 'Fruit Salad', description: 'Fresh seasonal fruits', claimed: false, claimedByDiscordId: '', claimedAt: '' },
-        { id: 6, name: 'Pasta Primavera', description: 'Pasta with fresh vegetables', claimed: false, claimedByDiscordId: '', claimedAt: '' },
-        { id: 7, name: 'Chicken Wings', description: 'Spicy buffalo wings', claimed: false, claimedByDiscordId: '', claimedAt: '' },
-        { id: 8, name: 'Cheese Platter', description: 'Assorted cheeses and crackers', claimed: false, claimedByDiscordId: '', claimedAt: '' }
+        {
+            id: 1,
+            name: 'Caesar Salad',
+            description: 'Fresh romaine lettuce with homemade dressing',
+            page: 63,
+            categories: ['Salad'],
+            ingredients: 'romaine lettuce; croutons; parmesan; Caesar dressing',
+            claimed: false,
+            claimedByDiscordId: '',
+            claimedAt: ''
+        },
+        {
+            id: 2,
+            name: 'Garlic Bread',
+            description: 'Crispy bread with garlic butter',
+            page: 72,
+            categories: ['Side'],
+            ingredients: 'baguette; garlic; butter; parsley',
+            claimed: false,
+            claimedByDiscordId: '',
+            claimedAt: ''
+        },
+        {
+            id: 3,
+            name: 'Chocolate Brownies',
+            description: 'Rich and fudgy brownies',
+            page: 105,
+            categories: ['Dessert'],
+            ingredients: 'chocolate; flour; sugar; eggs; butter',
+            claimed: false,
+            claimedByDiscordId: '',
+            claimedAt: ''
+        },
+        {
+            id: 4,
+            name: 'Vegetable Stir Fry',
+            description: 'Mixed vegetables with soy sauce',
+            page: 88,
+            categories: ['Main course'],
+            ingredients: 'assorted vegetables; soy sauce; sesame oil',
+            claimed: false,
+            claimedByDiscordId: '',
+            claimedAt: ''
+        },
+        {
+            id: 5,
+            name: 'Fruit Salad',
+            description: 'Fresh seasonal fruits',
+            page: 12,
+            categories: ['Dessert'],
+            ingredients: 'mixed fresh fruit',
+            claimed: false,
+            claimedByDiscordId: '',
+            claimedAt: ''
+        },
+        {
+            id: 6,
+            name: 'Pasta Primavera',
+            description: 'Pasta with fresh vegetables',
+            page: 144,
+            categories: ['Main course'],
+            ingredients: 'pasta; seasonal vegetables; olive oil; parmesan',
+            claimed: false,
+            claimedByDiscordId: '',
+            claimedAt: ''
+        },
+        {
+            id: 7,
+            name: 'Chicken Wings',
+            description: 'Spicy buffalo wings',
+            page: 175,
+            categories: ['Appetizer'],
+            ingredients: 'chicken wings; hot sauce; butter',
+            claimed: false,
+            claimedByDiscordId: '',
+            claimedAt: ''
+        },
+        {
+            id: 8,
+            name: 'Cheese Platter',
+            description: 'Assorted cheeses and crackers',
+            page: 5,
+            categories: ['Appetizer'],
+            ingredients: 'assorted cheese; crackers; fruit',
+            claimed: false,
+            claimedByDiscordId: '',
+            claimedAt: ''
+        }
     ],
     
     // Event configuration

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Recipe Sign-Up</title>
-    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <link rel="icon" href="./favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -48,7 +48,7 @@
                         <select id="recipe" name="recipe">
                             <option value="">Select a recipe...</option>
                         </select>
-                        <div class="recipe-info" id="recipeInfo"></div>
+                        <div class="recipe-entry" id="recipeEntry" style="display:none;"></div>
                     </div>
                     <div class="form-group">
                         <label for="notes">Anything else we should know?</label>

--- a/script.js
+++ b/script.js
@@ -16,7 +16,7 @@ class RecipeSignupForm {
         this.cookingRadios = document.querySelectorAll('input[name="cooking"]');
         this.recipeSelect = document.getElementById('recipe');
         this.recipeGroup = document.getElementById('recipeGroup');
-        this.recipeInfo = document.getElementById('recipeInfo');
+        this.recipeEntry = document.getElementById('recipeEntry');
         this.submitBtn = document.getElementById('submitBtn');
         this.messageDiv = document.getElementById('message');
         this.notesField = document.getElementById('notes');
@@ -184,7 +184,8 @@ class RecipeSignupForm {
             this.recipeGroup.style.display = 'none';
             this.recipeSelect.required = false;
             this.recipeSelect.value = '';
-            this.recipeInfo.style.display = 'none';
+            this.recipeEntry.style.display = 'none';
+            this.recipeEntry.innerHTML = '';
         }
         
         this.validateForm();
@@ -192,18 +193,107 @@ class RecipeSignupForm {
     
     handleRecipeChange() {
         const selectedRecipeId = parseInt(this.recipeSelect.value);
-        
+
         if (selectedRecipeId) {
             const recipe = this.recipes.find(r => r.id === selectedRecipeId);
             if (recipe) {
-                this.recipeInfo.textContent = recipe.description;
-                this.recipeInfo.style.display = 'block';
+                this.renderRecipeEntry(recipe);
+                this.recipeEntry.style.display = 'block';
             }
         } else {
-            this.recipeInfo.style.display = 'none';
+            this.recipeEntry.style.display = 'none';
+            this.recipeEntry.innerHTML = '';
         }
-        
+
         this.validateForm();
+    }
+
+    renderRecipeEntry(recipe) {
+        const entry = document.createElement('div');
+        entry.className = 'recipe-entry';
+
+        // Title
+        const title = document.createElement('div');
+        title.className = 'title';
+        title.textContent = recipe.name || '';
+        entry.appendChild(title);
+
+        // Page
+        if (recipe.page) {
+            const row = document.createElement('div');
+            row.className = 'meta-row';
+
+            const label = document.createElement('span');
+            label.className = 'label';
+            label.textContent = 'Page';
+            row.appendChild(label);
+
+            const pill = document.createElement('span');
+            pill.className = 'pill neutral';
+            pill.textContent = recipe.page;
+            row.appendChild(pill);
+
+            entry.appendChild(row);
+        }
+
+        // Categories
+        let categories = recipe.categories;
+        if (typeof categories === 'string') {
+            categories = categories.split(/[,;]+/).map(c => c.trim()).filter(Boolean);
+        }
+        if (Array.isArray(categories) && categories.length) {
+            const row = document.createElement('div');
+            row.className = 'meta-row';
+
+            const label = document.createElement('span');
+            label.className = 'label';
+            label.textContent = 'Categories';
+            row.appendChild(label);
+
+            categories.forEach((cat, idx) => {
+                const pill = document.createElement('span');
+                pill.className = 'pill ' + (idx % 2 === 0 ? 'pink' : 'blue');
+                pill.textContent = cat;
+                row.appendChild(pill);
+            });
+
+            entry.appendChild(row);
+        }
+
+        // Ingredients
+        let ingredientsText = recipe.ingredients;
+        if (Array.isArray(ingredientsText)) {
+            ingredientsText = ingredientsText.join('; ');
+        }
+        if (ingredientsText) {
+            const row = document.createElement('div');
+            row.className = 'meta-row ingredients';
+
+            const label = document.createElement('span');
+            label.className = 'label';
+            label.textContent = 'Ingredients';
+            row.appendChild(label);
+
+            const textSpan = document.createElement('span');
+            textSpan.id = 'ingredient-text';
+            textSpan.className = 'ingredient-text collapsed';
+            textSpan.textContent = ingredientsText;
+            row.appendChild(textSpan);
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'toggle-button';
+            button.setAttribute('aria-expanded', 'false');
+            button.setAttribute('aria-controls', 'ingredient-text');
+            button.textContent = 'Show more';
+            button.addEventListener('click', () => toggleIngredientText());
+            row.appendChild(button);
+
+            entry.appendChild(row);
+        }
+
+        this.recipeEntry.innerHTML = '';
+        this.recipeEntry.appendChild(entry);
     }
     
     validateForm() {
@@ -382,7 +472,8 @@ class RecipeSignupForm {
     resetForm() {
         this.form.reset();
         this.recipeGroup.style.display = 'none';
-        this.recipeInfo.style.display = 'none';
+        this.recipeEntry.style.display = 'none';
+        this.recipeEntry.innerHTML = '';
         this.recipeSelect.required = false;
         this.submitBtn.disabled = true;
         this.cookingRadios.forEach(r => r.parentElement.classList.remove('selected'));
@@ -395,4 +486,18 @@ class RecipeSignupForm {
 document.addEventListener('DOMContentLoaded', () => {
     new RecipeSignupForm();
 });
+
+function toggleIngredientText() {
+    const text = document.getElementById('ingredient-text');
+    const button = document.querySelector('.toggle-button');
+    if (!text || !button) return;
+    const expanded = text.classList.toggle('expanded');
+    if (expanded) {
+        text.classList.remove('collapsed');
+    } else {
+        text.classList.add('collapsed');
+    }
+    button.textContent = expanded ? 'Show less' : 'Show more';
+    button.setAttribute('aria-expanded', expanded);
+}
 

--- a/style.css
+++ b/style.css
@@ -15,18 +15,27 @@ body {
 }
 
 .layout {
-  display: flex;
+  /* two equal columns using grid */
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   min-height: 100vh;
 }
 
 .hero {
-  flex: 1;
+  /* fixed book cover anchored on the left */
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 50%;
+  height: 100vh;
   background: url('https://images-ext-1.discordapp.net/external/77OXjRmw5FPm5119nvN0LN5oygQP4w1-RPBvqUzaugg/https/m.media-amazon.com/images/I/81z109bNPzL._AC_UF1000%2C1000_QL80_.jpg?auto=format&fit=crop&w=800&q=60')
     center/cover no-repeat;
 }
 
 .cards {
-  flex: 1;
+  /* scrolling form content on the right */
+  margin-left: 50%;
+  width: 50%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -202,16 +211,84 @@ button:disabled {
 }
 
 @media (max-width: 768px) {
+  /* collapse to single column on small screens */
   .layout {
-    flex-direction: column;
+    grid-template-columns: 1fr;
   }
+  /* hero scrolls normally on mobile */
   .hero {
+    position: relative;
+    width: 100%;
     height: 200px;
   }
+  /* form spans full width below hero */
   .cards {
+    margin-left: 0;
+    width: 100%;
     padding: 24px;
   }
   .header-card h1 {
     font-size: 28px;
   }
+}
+
+/* Recipe metadata card */
+.recipe-entry {
+  background: white;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+  margin-top: 10px;
+}
+
+.recipe-entry .title {
+  font-weight: 600;
+  font-size: 17px;
+  margin-bottom: 10px;
+}
+
+.recipe-entry .meta-row {
+  margin-bottom: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.recipe-entry .label {
+  font-weight: 500;
+  color: #444;
+  margin-right: 6px;
+}
+
+.pill {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 500;
+  background-color: #e0e0e0;
+}
+.pill.pink { background-color: #fbd5e4; }
+.pill.blue { background-color: #d7e8fc; }
+.pill.neutral { background-color: #efefef; }
+
+.ingredient-text {
+  display: inline-block;
+  max-height: 60px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: all 0.3s ease;
+}
+.ingredient-text.expanded {
+  white-space: normal;
+}
+
+.toggle-button {
+  background: none;
+  border: none;
+  color: #007aff;
+  font-size: 14px;
+  cursor: pointer;
+  padding-left: 0;
 }


### PR DESCRIPTION
## Summary
- modernize the recipe details section with a card layout
- support categories, pages, and ingredients with sample data
- add collapsible ingredient text with JS toggle
- make the hero image fixed on desktop with responsive layout
- adjust favicon path

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_684dbbfa2d888323a512cd81469c27d3