### PR TITLE
Fix mobile ingredient display and metadata lookup

### DIFF
--- a/script.js
+++ b/script.js
@@ -102,7 +102,10 @@ class RecipeSignupForm {
             
             // 4. Filter the clean arrays
             const activeMembers = members.filter(m => m.active);
-            const availableRecipes = recipes.filter(r => !r.claimed);
+            const availableRecipes = recipes.filter(r => !r.claimed).map(r => ({
+                ...r,
+                id: parseInt(r.id, 10)
+            }));
             
             console.log('✅ Active members:', activeMembers.length);
             console.log('🆓 Available recipes:', availableRecipes.length);
@@ -192,10 +195,10 @@ class RecipeSignupForm {
     }
     
     handleRecipeChange() {
-        const selectedRecipeId = parseInt(this.recipeSelect.value);
+        const selectedRecipeId = this.recipeSelect.value;
 
         if (selectedRecipeId) {
-            const recipe = this.recipes.find(r => r.id === selectedRecipeId);
+            const recipe = this.recipes.find(r => String(r.id) === String(selectedRecipeId));
             if (recipe) {
                 this.renderRecipeEntry(recipe);
                 this.recipeEntry.style.display = 'block';
@@ -355,14 +358,14 @@ class RecipeSignupForm {
             discordId: discordId,
             displayName: member ? member.displayName : '',
             cooking: cookingValue === 'yes',
-            recipeId: cookingValue === 'yes' ? parseInt(this.recipeSelect.value) : null,
+            recipeId: cookingValue === 'yes' ? parseInt(this.recipeSelect.value, 10) : null,
             recipeName: '',
             notes: this.notesField.value.trim(),
             timestamp: new Date().toISOString()
         };
         
         if (formData.recipeId) {
-            const recipe = this.recipes.find(r => r.id === formData.recipeId);
+            const recipe = this.recipes.find(r => parseInt(r.id, 10) === formData.recipeId);
             formData.recipeName = recipe ? recipe.name : '';
         }
         

--- a/style.css
+++ b/style.css
@@ -272,14 +272,29 @@ button:disabled {
 
 .ingredient-text {
   display: inline-block;
-  max-height: 60px;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  transition: all 0.3s ease;
+  transition: max-height 0.3s ease;
 }
+
+.ingredient-text.collapsed {
+  max-height: 60px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .ingredient-text.expanded {
+  max-height: none;
   white-space: normal;
+}
+
+@media (max-width: 768px) {
+  .ingredient-text.collapsed {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    max-height: 3em;
+    white-space: normal;
+  }
 }
 
 .toggle-button {


### PR DESCRIPTION
## Summary
- clamp ingredient text on mobile so cards don't stretch
- parse recipe IDs consistently when loading data and submitting

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684dd362031c8323bd4ba2b6830b2f2c