### PR TITLE
Implement pastel category pills

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,48 @@
 // Recipe Sign-Up Form JavaScript
+
+// Pastel palette for category pills
+const PILL_COLORS = [
+    '#F8D7DA', // soft rose
+    '#FFF3CD', // pale gold
+    '#D1ECF1', // baby aqua
+    '#D4EDDA', // mint
+    '#E2D6F8', // lavender
+    '#FDE2E4', // peach
+    '#E8F0FE', // light sky
+    '#F0F3F5', // light gray
+    '#FFEBE5', // blush
+    '#EAF7E0'  // pistachio
+];
+
+// Map to keep a deterministic color for each category
+const categoryColorMap = new Map();
+let nextColorIndex = 0;
+
+/**
+ * Render pastel category pills into the given container.
+ * Each new category gets the next color from the palette.
+ */
+function renderCategoryPills(categories, container) {
+    // Remove any existing pills to avoid duplicates
+    container.querySelectorAll('.pill').forEach(p => p.remove());
+
+    categories.forEach(cat => {
+        const key = String(cat).trim();
+
+        if (!categoryColorMap.has(key)) {
+            categoryColorMap.set(key, PILL_COLORS[nextColorIndex]);
+            nextColorIndex = (nextColorIndex + 1) % PILL_COLORS.length;
+        }
+
+        const pill = document.createElement('span');
+        pill.className = 'pill';
+        pill.textContent = key;
+        pill.style.backgroundColor = categoryColorMap.get(key);
+
+        container.appendChild(pill);
+    });
+}
+
 class RecipeSignupForm {
     constructor() {
         this.members = [];
@@ -261,12 +305,11 @@ class RecipeSignupForm {
             label.textContent = 'Categories';
             row.appendChild(label);
 
-            categories.forEach((cat, idx) => {
-                const pill = document.createElement('span');
-                pill.className = 'pill ' + (idx % 2 === 0 ? 'pink' : 'blue');
-                pill.textContent = cat;
-                row.appendChild(pill);
-            });
+            const pillContainer = document.createElement('span');
+            row.appendChild(pillContainer);
+
+            // Render pastel pills for each category
+            renderCategoryPills(categories, pillContainer);
 
             entry.appendChild(row);
         }

--- a/style.css
+++ b/style.css
@@ -260,15 +260,18 @@ button:disabled {
 }
 
 .pill {
+  display: inline-block;
+  margin: 0 4px 4px 0;
   padding: 4px 10px;
   border-radius: 999px;
   font-size: 13px;
   font-weight: 500;
-  background-color: #e0e0e0;
+  color: #333;
+  /* background-color is set inline via JavaScript */
 }
-.pill.pink { background-color: #fbd5e4; }
-.pill.blue { background-color: #d7e8fc; }
-.pill.neutral { background-color: #efefef; }
+.pill.neutral {
+  background-color: #efefef;
+}
 
 .ingredient-text {
   display: inline-block;


### PR DESCRIPTION
## Summary
- add pastel color palette and color assignment helpers in `script.js`
- render category pills using deterministically assigned colors
- clean up `.pill` styles and remove pink/blue classes

## Testing
- `node -v`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_684df26e463c83239bca90aea5259261