### PR TITLE
Adjust hero layout for desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,9 @@
 </head>
 <body>
     <div class="layout">
-        <div class="hero" role="img" aria-label="Food on table"></div>
+        <div class="hero">
+            <img class="hero-img" src="https://images-ext-1.discordapp.net/external/77OXjRmw5FPm5119nvN0LN5oygQP4w1-RPBvqUzaugg/https/m.media-amazon.com/images/I/81z109bNPzL._AC_UF1000%2C1000_QL80_.jpg?auto=format&fit=crop&w=800&q=60" alt="Food on table">
+        </div>
         <main class="cards">
             <section class="card header-card">
                 <h1>Shared Table RSVP • June 2025</h1>

--- a/style.css
+++ b/style.css
@@ -15,9 +15,9 @@ body {
 }
 
 .layout {
-  /* two equal columns using grid */
+  /* two-column grid with a narrow hero on desktop */
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 35vw 1fr;
   min-height: 100vh;
 }
 
@@ -27,8 +27,13 @@ body {
   top: 0;
   height: 100vh;
   width: 100%;
-  background: url('https://images-ext-1.discordapp.net/external/77OXjRmw5FPm5119nvN0LN5oygQP4w1-RPBvqUzaugg/https/m.media-amazon.com/images/I/81z109bNPzL._AC_UF1000%2C1000_QL80_.jpg?auto=format&fit=crop&w=800&q=60')
-    center/cover no-repeat;
+  overflow: hidden;
+}
+
+.hero-img {
+  height: 100%;
+  width: 100%;
+  object-fit: contain;
 }
 
 .cards {


### PR DESCRIPTION
## Summary
- restructure hero markup to include an `<img>` element
- add responsive CSS so the hero only occupies ~35% of the viewport width on desktop
- keep the image full-height using `height: 100vh` and `object-fit: contain`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e499544588323be61e49211414786