### PR TITLE
Refactor HTML layout with hero banner and two-column wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,59 +8,61 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="layout">
-        <div class="hero" role="img" aria-label="Food on table"></div>
-        <main class="cards">
-            <section class="card header-card">
-                <h1>Shared Table RSVP • June 2025</h1>
-                <p>Come share a meal with friends and neighbors.</p>
-                <p>Claim a dish or just join the feast!</p>
-                <hr>
-            </section>
-            <section class="card form-card">
-                <form id="recipeForm" novalidate>
-                    <input type="hidden" id="eventName" name="eventName" readonly>
-                    <div class="form-group">
-                        <label for="member">Who are you? *</label>
-                        <input id="member" name="member" list="member-list" placeholder="Start typing your name…" required>
-                        <datalist id="member-list"></datalist>
+    <div class="hero">
+        <img src="hero-banner.webp" alt="Event Hero" loading="lazy">
+        <h1>Shared Table RSVP • June 2025</h1>
+        <p>Come share a meal with friends and neighbors. Claim a dish or just join!</p>
+    </div>
+
+    <div class="main-container">
+        <div class="form-card">
+            <form id="recipeForm" novalidate>
+                <input type="hidden" id="eventName" name="eventName" readonly>
+                <div class="form-group">
+                    <label for="member">Who are you? *</label>
+                    <input id="member" name="member" list="member-list" placeholder="Start typing your name…" required>
+                    <datalist id="member-list"></datalist>
+                </div>
+                <div class="form-group">
+                    <label>How are you joining? *</label>
+                    <div class="radio-group" id="cookingGroup">
+                        <label class="radio-card">
+                            <input type="radio" name="cooking" value="yes">
+                            <span class="icon">👩‍🍳</span>
+                            <span class="title">Cooking something</span>
+                            <span class="subtitle">I'll bring a dish</span>
+                        </label>
+                        <label class="radio-card">
+                            <input type="radio" name="cooking" value="no">
+                            <span class="icon">🍽️</span>
+                            <span class="title">Just showing up</span>
+                            <span class="subtitle">I'm here to eat</span>
+                        </label>
                     </div>
-                    <div class="form-group">
-                        <label>How are you joining? *</label>
-                        <div class="radio-group" id="cookingGroup">
-                            <label class="radio-card">
-                                <input type="radio" name="cooking" value="yes">
-                                <span class="icon">👩‍🍳</span>
-                                <span class="title">Cooking something</span>
-                                <span class="subtitle">I'll bring a dish</span>
-                            </label>
-                            <label class="radio-card">
-                                <input type="radio" name="cooking" value="no">
-                                <span class="icon">🍽️</span>
-                                <span class="title">Just showing up</span>
-                                <span class="subtitle">I'm here to eat</span>
-                            </label>
-                        </div>
-                    </div>
-                    <div class="form-group" id="recipeGroup" style="display:none;">
-                        <label for="recipe">What are you cooking? *</label>
-                        <input id="recipe" name="recipe" list="recipe-list" placeholder="Start typing your recipe…">
-                        <datalist id="recipe-list"></datalist>
-                        <div class="recipe-entry" id="recipeEntry" style="display:none;"></div>
-                    </div>
-                    <div class="form-group">
-                        <label for="notes">Anything else we should know?</label>
-                        <span class="sub-label">This note will post in Discord…</span>
-                        <textarea id="notes" name="notes"></textarea>
-                    </div>
-                    <button type="submit" id="submitBtn" disabled>
-                        <span class="btn-text">Submit RSVP</span>
-                        <span class="btn-loading" style="display:none;">Submitting...</span>
-                    </button>
-                </form>
-                <div id="message" class="message"></div>
-            </section>
-        </main>
+                </div>
+                <div class="form-group" id="recipeGroup" style="display:none;">
+                    <label for="recipe">What are you cooking? *</label>
+                    <input id="recipe" name="recipe" list="recipe-list" placeholder="Start typing your recipe…">
+                    <datalist id="recipe-list"></datalist>
+                    <div class="recipe-entry" id="recipeEntry" style="display:none;"></div>
+                </div>
+                <div class="form-group">
+                    <label for="notes">Anything else we should know?</label>
+                    <span class="sub-label">This note will post in Discord…</span>
+                    <textarea id="notes" name="notes"></textarea>
+                </div>
+                <button type="submit" id="submitBtn" disabled>
+                    <span class="btn-text">Submit RSVP</span>
+                    <span class="btn-loading" style="display:none;">Submitting...</span>
+                </button>
+            </form>
+            <div id="message" class="message"></div>
+        </div>
+
+        <div class="menu-card">
+            <h2>Menu In Progress</h2>
+            <div class="menu-list"><!-- Claimed dishes will be injected here by JavaScript --></div>
+        </div>
     </div>
 
     <script src="config.js"></script>


### PR DESCRIPTION
## Summary
- add a hero banner with image, heading and intro text
- wrap page content in `main-container`
- move the RSVP form into `form-card`
- add placeholder `menu-card` for menu list

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_684e69b38f4c8323bc0a9144c480ef7f