### PR TITLE
Split hero into image and text blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,14 @@
 </head>
 <body>
     <div class="hero">
-        <img src="hero-banner.webp" alt="Event Hero" loading="lazy">
-        <h1>Shared Table RSVP • June 2025</h1>
-        <p>Come share a meal with friends and neighbors. Claim a dish or just join!</p>
+        <div class="hero-image">
+            <!-- Image handled separately so text is not overlayed -->
+            <img src="hero-banner.webp" alt="Event Hero" loading="lazy">
+        </div>
+        <div class="hero-text">
+            <h1>Shared Table RSVP • June 2025</h1>
+            <p>Come share a meal with friends and neighbors. Claim a dish or just join!</p>
+        </div>
     </div>
 
     <div class="main-container">

--- a/style.css
+++ b/style.css
@@ -22,13 +22,33 @@ body {
 }
 
 .hero {
-  /* sticky book cover anchored on the left */
+  /* sticky container split into image and text halves */
   position: sticky;
   top: 0;
+  display: flex;
   height: 100vh;
   width: 100%;
-  background: url('https://images-ext-1.discordapp.net/external/77OXjRmw5FPm5119nvN0LN5oygQP4w1-RPBvqUzaugg/https/m.media-amazon.com/images/I/81z109bNPzL._AC_UF1000%2C1000_QL80_.jpg?auto=format&fit=crop&w=800&q=60')
-    center/cover no-repeat;
+}
+
+.hero-image {
+  flex: 1;
+}
+
+.hero-image img {
+  /* ensure image always covers its half */
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.hero-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 32px;
+  background: #F7F7F7;
 }
 
 .cards {
@@ -213,10 +233,14 @@ button:disabled {
   .layout {
     grid-template-columns: 1fr;
   }
-  /* hero scrolls normally on mobile */
+  /* hero stacks image and text on mobile */
   .hero {
     position: relative;
+    flex-direction: column;
     width: 100%;
+    height: auto;
+  }
+  .hero-image {
     height: 200px;
   }
   /* form spans full width below hero */


### PR DESCRIPTION
## Summary
- split hero banner markup into `.hero-image` and `.hero-text` wrappers
- style hero layout to show an image block and textual block
- stack the hero blocks on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684efa24535483239179bf34995455cf