### PR TITLE
Switch to responsive banner image

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,16 +8,13 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="hero">
-        <div class="hero-image">
-            <!-- Image handled separately so text is not overlayed -->
-            <img src="hero-banner.webp" alt="Event Hero" loading="lazy">
-        </div>
-        <div class="hero-text">
-            <h1>Shared Table RSVP • June 2025</h1>
-            <p>Come share a meal with friends and neighbors. Claim a dish or just join!</p>
-        </div>
-    </div>
+    <header class="banner">
+        <img src="hero-banner.webp" alt="Event Hero" loading="lazy">
+    </header>
+    <section class="intro">
+        <h1>Shared Table RSVP • June 2025</h1>
+        <p>Come share a meal with friends and neighbors. Claim a dish or just join!</p>
+    </section>
 
     <div class="main-container">
         <div class="form-card">

--- a/style.css
+++ b/style.css
@@ -21,33 +21,16 @@ body {
   min-height: 100vh;
 }
 
-.hero {
-  /* sticky container split into image and text halves */
-  position: sticky;
-  top: 0;
-  display: flex;
-  height: 100vh;
+.banner img {
   width: 100%;
-}
-
-.hero-image {
-  flex: 1;
-}
-
-.hero-image img {
-  /* ensure image always covers its half */
-  width: 100%;
-  height: 100%;
+  max-height: 400px;
   object-fit: cover;
   display: block;
 }
 
-.hero-text {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
+.intro {
   padding: 32px;
+  text-align: center;
   background: #F7F7F7;
 }
 
@@ -233,17 +216,8 @@ button:disabled {
   .layout {
     grid-template-columns: 1fr;
   }
-  /* hero stacks image and text on mobile */
-  .hero {
-    position: relative;
-    flex-direction: column;
-    width: 100%;
-    height: auto;
-  }
-  .hero-image {
-    height: 200px;
-  }
-  /* form spans full width below hero */
+  /* banner simply scales on small screens */
+  /* form spans full width below banner */
   .cards {
     margin-left: 0;
     width: 100%;


### PR DESCRIPTION
## Summary
- remove full-height hero layout
- add top banner image and intro section
- simplify responsive rules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684efd2b880c8323ab104b3a7f061b84