### PR TITLE
Refactor hero layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,14 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <header class="banner">
-        <img src="hero-banner.webp" alt="Event Hero" loading="lazy">
-    </header>
-    <section class="intro">
-        <h1>Shared Table RSVP · June 2025</h1>
-        <p>This month’s book is That Sounds So Good by Carla Lalli Music — brought to the table by Kristyn (@LilGucky). RSVP below to let us know how you’re joining.</p>
-    </section>
+    <div class="hero">
+        <img src="hero-banner.webp" alt="That Sounds So Good book cover" />
+    </div>
+
+    <div class="hero-text">
+        <h1>Shared Table RSVP • June 2025</h1>
+        <p>This month’s book is That Sounds So Good by Carla Lalli Music — brought to the table by Kristyn (@LilGucky). RSVP below to let us know how you're joining.</p>
+    </div>
 
     <div class="main-container">
         <div class="form-card">

--- a/style.css
+++ b/style.css
@@ -34,12 +34,49 @@ body {
   background: #F7F7F7;
 }
 
+/* Hero section with centered image */
+.hero {
+  background-color: #fffdf7; /* soft neutral */
+  padding: 2rem 0;           /* top and bottom breathing room */
+  text-align: center;
+}
+
+.hero img {
+  max-height: 400px;
+  max-width: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  display: block;
+  margin: 0 auto;
+}
+
+.hero-text {
+  max-width: 700px;
+  margin: 0 auto 2rem;
+  padding: 0 1rem;
+  text-align: center;
+}
+
+.hero-text h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.hero-text p {
+  font-size: 1rem;
+  font-weight: 400;
+  color: #555;
+}
+
 /* Grid container holding the RSVP form and menu list */
 .main-container {
   display: grid; /* two columns on desktop */
   grid-template-columns: 2fr 3fr;
   gap: 32px;
   padding: 32px;
+  margin-top: 2rem;
 }
 
 /* Card styling for each column */


### PR DESCRIPTION
## Summary
- reduce hero dominance and show entire cover image
- center and pad the heading/description
- give the main container top margin

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f24279f2c8323a105da5771001cbe