### PR TITLE
Create two-column main layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,17 +8,17 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="hero">
-        <img src="hero-banner.webp" alt="That Sounds So Good book cover" />
-    </div>
-
-    <div class="hero-text">
-        <h1>Shared Table RSVP • June 2025</h1>
-        <p>This month’s book is That Sounds So Good by Carla Lalli Music — brought to the table by Kristyn (@LilGucky). RSVP below to let us know how you're joining.</p>
-    </div>
-
-    <div class="main-container">
-        <div class="form-card">
+    <div class="main-wrapper">
+        <div class="cover-column">
+            <img src="hero-banner.webp" alt="That Sounds So Good book cover" />
+        </div>
+        <div class="content-column">
+            <div class="hero-text">
+                <h1>Shared Table RSVP • June 2025</h1>
+                <p>This month’s book is That Sounds So Good by Carla Lalli Music — brought to the table by Kristyn (@LilGucky). RSVP below to let us know how you're joining.</p>
+            </div>
+            <div class="main-container">
+                <div class="form-card">
             <form id="recipeForm" novalidate>
                 <input type="hidden" id="eventName" name="eventName" readonly>
                 <div class="form-group">
@@ -82,6 +82,7 @@
                     <div class="page-num">Page 45</div>
                 </div>
             </div>
+        </div>
         </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -70,6 +70,32 @@ body {
   color: #555;
 }
 
+/* Wrapper grid for cover and content */
+.main-wrapper {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.cover-column {
+  background-color: #fffdf7;
+  padding: 2rem 0;
+  text-align: center;
+}
+
+.cover-column img {
+  max-height: 400px;
+  max-width: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  display: block;
+  margin: 0 auto;
+}
+
 /* Grid container holding the RSVP form and menu list */
 .main-container {
   display: grid; /* two columns on desktop */
@@ -305,6 +331,9 @@ button:disabled {
 @media (max-width: 768px) {
   /* collapse to single column on small screens */
   .layout {
+    grid-template-columns: 1fr;
+  }
+  .main-wrapper {
     grid-template-columns: 1fr;
   }
   .main-container {


### PR DESCRIPTION
## Summary
- add `.main-wrapper` grid with cover and content columns
- move hero image, text, and form into new wrapper
- style new wrapper and make it responsive

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684f414cfd8883238181e6bdb2f9782b