### PR TITLE
Fix closing tags for layout wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
         </div>
         </div>
     </div>
+    </div>
 
     <script src="config.js"></script>
     <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- ensure `.main-wrapper` closes properly so the form and menu stay in the right column

## Testing
- `grep -o '<div' index.html | wc -l`
- `grep -o '</div>' index.html | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_684f48712188832389db173ddd9a4d19