### PR TITLE
Refine book cover layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,6 +14,11 @@ body {
   min-height: 100vh;
 }
 
+/* aspect ratio of the book cover (width / height) */
+:root {
+  --cover-ratio: 0.806;
+}
+
 .layout {
   /* two equal columns using grid */
   display: grid;
@@ -77,19 +82,52 @@ body {
   max-width: 1200px;
   margin: 0 auto;
   padding: 2rem 1rem;
+  align-items: flex-start; /* prevent column stretch so cover doesn't fill entire height */
 }
 
 .cover-column {
   display: flex;
-  align-items: flex-start; /* <-- top-align */
-  justify-content: center;
+  align-items: flex-start; /* top align image */
+  justify-content: flex-start; /* anchor to left */
   padding-top: 0;
   padding-bottom: 0;
 }
 .cover-column img {
-  height: 100%;
-  object-fit: contain;
+  width: 100%;
+  height: auto;
+  max-height: 100vh; /* scale down on smaller screens */
+  object-fit: contain; /* keep full image visible */
+  object-position: center top; /* anchor to the top */
   display: block;
+}
+
+/* Desktop layout: show full-height cover anchored to the viewport */
+@media (min-width: 1024px) {
+  body {
+    overflow-x: hidden; /* prevent scroll from offscreen cover */
+  }
+
+  .main-wrapper {
+    /* offset content to the right of the fixed cover */
+    display: block;
+    max-width: none;
+    padding-left: calc(100vh * var(--cover-ratio) + 2rem);
+  }
+
+  .cover-column {
+    position: fixed;
+    inset: 0 auto 0 0; /* top/right/bottom/left */
+    width: calc(100vh * var(--cover-ratio));
+    overflow: hidden; /* crop on the right */
+    padding: 0;
+  }
+
+  .cover-column img {
+    height: 100vh; /* span the viewport vertically */
+    width: auto;
+    object-fit: contain; /* scale so the whole height is visible */
+    object-position: center; /* center horizontally within column */
+  }
 }
 
 /* Grid container holding the RSVP form and menu list */


### PR DESCRIPTION
## Summary
- anchor the full-size cover against the viewport on desktop
- add `--cover-ratio` variable for sizing
- ensure the image scales down instead of cropping vertically

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f4c88127483238fe78d67ceca2cbe