### PR TITLE
Display live claimed recipes in menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,22 +66,7 @@
         <div class="menu-card">
             <h2>Menu In Progress</h2>
             <div class="menu-list">
-                <!-- Placeholder menu entries -->
-                <div class="menu-item">
-                    <div class="recipe-name">Eggplant Parmesan</div>
-                    <div class="claimed-by">Claimed by AliceChef</div>
-                    <div class="page-num">Page 123</div>
-                </div>
-                <div class="menu-item">
-                    <div class="recipe-name">Lemon Tart</div>
-                    <div class="claimed-by">Claimed by BobCooks</div>
-                    <div class="page-num">Page 89</div>
-                </div>
-                <div class="menu-item">
-                    <div class="recipe-name">Miso Soup</div>
-                    <div class="claimed-by">Claimed by CarolKitchen</div>
-                    <div class="page-num">Page 45</div>
-                </div>
+                <!-- menu items will be injected here -->
             </div>
         </div>
         </div>


### PR DESCRIPTION
## Summary
- display claimed recipes from backend in `Menu In Progress`
- store full recipe list to separate claimed and available ones
- render claimed dish with name, claimant and page number
- strip placeholder HTML from menu section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f7b789de08323a4171127ebb8eb11